### PR TITLE
Add instructions for running the cloud multi-project example locally

### DIFF
--- a/multi-location-project/README.md
+++ b/multi-location-project/README.md
@@ -30,3 +30,19 @@ This example shows how to create a dagster project with two code locations. Each
 ./location2-dir/location2/__init__.py
 ./location2-dir/location2/assets.py
 ```
+
+## Running locally
+To run locally via `dagster dev`, pip install the two projects:
+
+```
+cd ./location1-dir
+pip install -e .[dev] -r requirements.txt
+cd ../location2-dir
+pip install -e .[dev] -r requirements.txt
+```
+
+And run `dagster dev` in this folder, which will use the `workspace.yaml` file to load both Dagster projects in the Dagster UI:
+
+```
+dagster dev
+```

--- a/multi-location-project/location1-dir/setup.py
+++ b/multi-location-project/location1-dir/setup.py
@@ -8,5 +8,5 @@ setup(
         "dagster-cloud",
         "cowsay==5.0",
     ],
-    extras_require={"dev": ["dagit", "pytest"]},
+    extras_require={"dev": ["dagster-webserver", "pytest"]},
 )

--- a/multi-location-project/location2-dir/setup.py
+++ b/multi-location-project/location2-dir/setup.py
@@ -8,5 +8,5 @@ setup(
         "dagster-cloud",
         "cowsay==4.0",
     ],
-    extras_require={"dev": ["dagit", "pytest"]},
+    extras_require={"dev": ["dagster-webserver", "pytest"]},
 )

--- a/multi-location-project/workspace.yaml
+++ b/multi-location-project/workspace.yaml
@@ -1,0 +1,9 @@
+load_from:
+  - python_package:
+      package_name: location1
+      location_name: location1
+#      working_directory: location1-dir
+  - python_package:
+      package_name: location2
+      location_name: location2
+#      working_directory: location2-dir


### PR DESCRIPTION
Summary:
This example only has a dagster_cloud.yaml and a way of running each project individually, but no way to run them together in a single `dagster dev` command. Add a `workspace.yaml` file and instructions for how to run the project locally.
